### PR TITLE
allow for errorHandler middleware

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,9 @@ module.exports = {
         return wrapRouter(express.Router.apply(express, arguments));
     },
     wrapRouter,
-    wrapFunction
+    wrapFunction: function (fn) {
+        return wrapMiddleware('', '', fn);
+    }
 };
 
 function wrapRouter(app, methods = ['use', 'get', 'post', 'put', 'patch', 'delete', 'head']) {
@@ -17,14 +19,14 @@ function wrapRouter(app, methods = ['use', 'get', 'post', 'put', 'patch', 'delet
     for (const method of methods) {
         const fn = app[method];
         app[method] = function () {
-            const args = wrapArgs(arguments);
+            const args = wrapArgs(method, arguments);
             return fn.apply(app, args);
         };
     }
     return app;
 }
 
-function wrapArgs(args) {
+function wrapArgs(method, args) {
     const ret = [];
     for (const fn of args) {
         switch (typeOf(fn)) {
@@ -32,32 +34,80 @@ function wrapArgs(args) {
                 ret.push(fn);
                 continue;
             case 'array':
-                ret.push(wrapArgs(fn));
+                ret.push(wrapArgs(method, fn));
                 return ret;
             case 'function':
-                ret.push(wrapFunction(fn));
+                ret.push(wrapMiddleware(method, args[0], fn));
                 continue;
         }
     }
     return ret;
 }
 
-function wrapFunction(fn) {
-    return async function asyncWrapper(...args) {
+function wrapMiddleware(method, path, fn) {
+    // response handler: function (req, res) { ... }
+    if (fn.length === 2) {
+        return function asyncWrapper2(req, res) {
+            return handleResult(method, path, fn, arguments, res, arguments[2]);
+        };
+    }
+
+    // middleware: function (req, res, next) { ... }
+    if (fn.length === 3) {
+        return function asyncWrapper3(req, res, next) {
+            return handleResult(method, path, fn, arguments, res, next);
+        };
+    }
+
+    // error handler: function (req, res, next) { ... }
+    if (fn.length === 4) {
+        /* eslint-disable node/handle-callback-err */
+        return function asyncWrapper4(err, req, res, next) {
+            return handleResult(method, path, fn, arguments, res, next);
+        };
+    }
+
+    // other
+    return function asyncWrapperN(...args) {
         const next = findNext(args);
         const res = findResponse(args);
-        try {
-            const response = await fn.apply(fn, args);
-            if (res.headersSent) {
-                return;
-            }
-            if (response) {
-                return res.send(response);
-            }
-        } catch (err) {
-            if (!res.headersSent) {
-                next(err);
-            }
-        }
+        return handleResult(method, path, fn, args, res, next);
     };
+}
+
+async function handleResult(method, path, fn, args, res, next) {
+    if (path !== 'string') {
+        // implicit app.use(fn) or app.get(fn) rather than app.get('/', fn)
+        path = '/';
+    }
+    try {
+        const response = await fn.apply(fn, args);
+        if (res.headersSent) {
+            return;
+        }
+        if (response) {
+            return res.send(response);
+        }
+        // otherwise expect that the middleware should call next()
+    } catch (err) {
+        let extra = '';
+        if (method) {
+            extra = ` '${method} ${path}'`;
+        }
+        if (!res.headersSent) {
+            if (typeof next === 'function') {
+                return next(err);
+            }
+
+            console.error(`express-promisify-router: Unhandled Error in Async Route${extra} without 'next':`);
+            console.error(err);
+            res.statusCode = 500;
+            res.end();
+            return;
+        }
+
+        // no sense in re-throwing at this point
+        console.error(`express-promisify-router: Unhandled Error in Async Route${extra} after Headers Sent:`);
+        console.error(err);
+    }
 }


### PR DESCRIPTION
# Update

I've also published my own version with the fix, and updated docs:

- `npm install --save @root/async-router`
- [@root/async-router](https://github.com/therootcompany/async-router)

# Original

Since the error function handler is very different, it cannot be handled generically.

Instead, wrap separately for each of the most common function signatures:

```js
function (req, res) {
    // complete request
}
```

```js
function (req, res, next) {
    // do middleware stuff
}
```

```js
function (err, req, res, next) {
    // handle errors
}
```