### PR TITLE
bugfix: allow for RegExp url patterns

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,10 @@ function wrapRouter(app, methods = ['use', 'get', 'post', 'put', 'patch', 'delet
 function wrapArgs(args) {
     const ret = [];
     for (const fn of args) {
+        if (fn instanceof RegExp) {
+            ret.push(fn);
+            continue;
+        }
         switch (typeOf(fn)) {
             case 'string':
                 ret.push(fn);


### PR DESCRIPTION
Also fixed in v1.0.10 of https://github.com/therootcompany/async-router.